### PR TITLE
修复安卓4.4.0以下的时候，没办法开启原生滚动条，现在判断滚动条类型的优先级是data-type>js判断系统版本号，即优先按照data…

### DIFF
--- a/js/scroller.js
+++ b/js/scroller.js
@@ -45,7 +45,7 @@
 
         var type = this.options.type;
         //auto的type,系统版本的小于4.4.0的安卓设备和系统版本小于6.0.0的ios设备，启用js版的iscoll
-        var useJSScroller = (type === 'js') || (type === 'auto' && ($.device.android && $.compareVersion('4.4.0', $.device.osVersion) > -1) || ($.device.ios && $.compareVersion('6.0.0', $.device.osVersion) > -1));
+        var useJSScroller = (type === 'js') || (type === 'auto' && ($.device.android && $.compareVersion('4.4.0', $.device.osVersion) > -1) || (type === 'auto' && ($.device.ios && $.compareVersion('6.0.0', $.device.osVersion) > -1)));
 
         if (useJSScroller) {
 


### PR DESCRIPTION
…-type的类型初始化滚动条，只有在auto情况下，会根据系统版本以及手机类型判断滚动条类型 #219